### PR TITLE
Reload ipsec service for rereading updated certs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kingsly-certbot (0.3.2)
+    kingsly-certbot (0.3.3)
       sentry-raven (~> 2.9, >= 2.9.0)
 
 GEM

--- a/lib/kingsly_certbot/ip_sec_cert_adapter.rb
+++ b/lib/kingsly_certbot/ip_sec_cert_adapter.rb
@@ -49,7 +49,7 @@ module KingslyCertbot
     end
 
     def restart_service
-      result = Kernel.system('systemctl stop strongswan.service; sleep 10; systemctl start strongswan.service; sleep 10')
+      result = Kernel.system('ipsec rereadall && ipsec reload')
       $logger.error('ipsec restart command failed') unless result
       result
     end

--- a/lib/kingsly_certbot/version.rb
+++ b/lib/kingsly_certbot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module KingslyCertbot
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end


### PR DESCRIPTION
    - Restarting strongswan isn't necessary