### PR TITLE
Reload ipsec service for rereading updated certs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kingsly-certbot (0.3.2)
+    kingsly-certbot (0.3.3)
       sentry-raven (~> 2.9, >= 2.9.0)
 
 GEM

--- a/lib/kingsly_certbot/ip_sec_cert_adapter.rb
+++ b/lib/kingsly_certbot/ip_sec_cert_adapter.rb
@@ -49,7 +49,7 @@ module KingslyCertbot
     end
 
     def restart_service
-      result = Kernel.system('systemctl stop strongswan.service; sleep 10; systemctl start strongswan.service; sleep 10')
+      result = Kernel.system('ipsec rereadall && ipsec reload')
       $logger.error('ipsec restart command failed') unless result
       result
     end

--- a/lib/kingsly_certbot/version.rb
+++ b/lib/kingsly_certbot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module KingslyCertbot
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end

--- a/spec/ip_sec_cert_adapter_spec.rb
+++ b/spec/ip_sec_cert_adapter_spec.rb
@@ -113,13 +113,13 @@ RSpec.describe KingslyCertbot::IpSecCertAdapter do
   context 'restart_service' do
     it 'should call ipsec restart and return true if success' do
       adapter = KingslyCertbot::IpSecCertAdapter.new(KingslyCertbot::CertBundle.new(nil, nil, nil, nil))
-      allow(Kernel).to receive(:system).with('systemctl stop strongswan.service; sleep 10; systemctl start strongswan.service; sleep 10').and_return(true)
+      allow(Kernel).to receive(:system).with('ipsec rereadall && ipsec reload').and_return(true)
       expect(adapter.restart_service).to eq(true)
     end
 
     it 'should return false and print error to standard error if restart_service returns false' do
       adapter = KingslyCertbot::IpSecCertAdapter.new(KingslyCertbot::CertBundle.new(nil, nil, nil, nil))
-      allow(Kernel).to receive(:system).with('systemctl stop strongswan.service; sleep 10; systemctl start strongswan.service; sleep 10').and_return(false)
+      allow(Kernel).to receive(:system).with('ipsec rereadall && ipsec reload').and_return(false)
       expect(adapter.restart_service).to eq(false)
     end
   end


### PR DESCRIPTION
- Restarting strongswan isn't necessary
- Current system has a flaw. Because strongswan's systemd script doesn't support reload, currently certbot sleeps waiting for strongswan to stop. If strongswan hasn't stopped in given time, start command fails, taking the VPN down when renewing the cert.